### PR TITLE
Fixes #3 CLS event values sent to GA aren't useful.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ or
 }
 ```
 
+## Important note
+
+Because Google Analytics metrics must be integers, all event values are rounded
+before being sent. To be meaningful, CLS values are also multiplied by 1000.
+This is the approach recommended in the [Web Vitals documentation](https://github.com/GoogleChrome/web-vitals#send-the-results-to-google-analytics) and will be
+important to keep in mind when preparing your reports.
+
 ---
 
 Plugin based on [`nuxt-vitals`](https://github.com/daliborgogic/nuxt-vitals).

--- a/src/web-vitals.js
+++ b/src/web-vitals.js
@@ -35,7 +35,8 @@ function sendToAnalytics(metric, options) {
     ea: name,
     el: id,
     // Google Analytics metrics must be integers, so the value is rounded.
-    ev: parseInt(delta),
+    // For CLS the value is first multiplied by 1000 for greater precision.
+    ev: Math.round(name === 'CLS' ? delta * 1000 : delta),
     dl: location.href,
     dp: location.pathname,
     ni: true,
@@ -52,6 +53,7 @@ function sendToAnalytics(metric, options) {
   const url = encode(obj);
 
   if (options.debug) {
+    onDebug(name + " original value", delta);
     onDebug(name, JSON.stringify(obj, null, 2));
     onDebug(name + " URL", url);
   }


### PR DESCRIPTION
I thought it might be useful to see the original event value when debugging, so I've added it to the `onDebug()` output. 

I have also updated the README, since the CLS values will need to be converted in GA reports. 

To minimize confusion it might be best to apply this PR to a new major version which also updates the web-vitals version dependency (which may of course require further changes to be compatible).  