### PR TITLE
Depend on web-vitals 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/bejamas/gatsby-plugin-web-vitals#readme",
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "web-vitals": "^0.2.1"
+    "web-vitals": "^2.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
This is a PR for [Update web-vitals dependency to 2.x branch #5](https://github.com/bejamas/gatsby-plugin-web-vitals/issues/5)

With this update there is a breaking change as described in the PR [Update CLS to max session window 5s cap 1s gap #148](https://github.com/GoogleChrome/web-vitals/pull/148):

> The only observable difference developers might notice to the API is previously the `metric.entries` array would only ever add new entries as additional shifts occurred on the page. With this change, only the entries from the max session window are reported, which means it could be the case the some of the entries referenced when CLS is first reported (e.g. after the tab is backgrounded), may not be the entries that are referenced the next time the tab is backgrounded. Developers not referencing the `metric.entries` array should not notice any differences other than a possible reduction in the value reported.

AFAICT this plugin only [references the performance entry of the TTFB metric to calculate request time](https://github.com/bejamas/gatsby-plugin-web-vitals/blob/master/src/web-vitals.js#L44-L48) so I'm fairly confident this plugin would be unaffected by the breaking change but a proper review is obviously in order.

Thanks!
